### PR TITLE
Install artifactory app at root path (/)

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,8 @@ This HELM chart is based on the [official docker-compose](https://releases.jfrog
 helm install artifactory-cpp-ce --namespace artifactory-cpp-ce ./chart --create-namespace
 ```
 
+By default, `Artifactory Community Edition for C and C++` will be installed. One can choose different products. For example, `--set artifactory.product=jcr` will install `JFrog Container Registry`.
+
 And then it can be accessed with:
 ```shell
 curl https://example.host/ -Lkv --resolve example.host:443:127.0.0.1

--- a/chart/Chart.yaml
+++ b/chart/Chart.yaml
@@ -1,5 +1,5 @@
-name: artifactory-ce
-description: Helm Chart for Artifactory C++ CE
+name: artifactory
+description: Helm Chart for Artifactory products
 version: 7.38.10
 apiVersion: v1
 home: https://jfrog.com/artifactory/

--- a/chart/templates/artifactory-deployment.yaml
+++ b/chart/templates/artifactory-deployment.yaml
@@ -41,7 +41,7 @@ spec:
             - name: JF_SHARED_DATABASE_TYPE
               value: postgresql
             - name: JF_SHARED_DATABASE_URL
-              value: jdbc:postgresql://{{ .Values.db.serviceName }}.artifactory-cpp-ce.svc.cluster.local:{{ .Values.db.port }}/{{ .Values.db.databaseName }}
+              value: jdbc:postgresql://{{ .Values.db.serviceName }}.{{ .Release.Namespace }}.svc.cluster.local:{{ .Values.db.port }}/{{ .Values.db.databaseName }}
             - name: JF_SHARED_DATABASE_USERNAME
               value: {{ .Values.db.user }}
             - name: JF_SHARED_NODE_ID
@@ -56,7 +56,7 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: "metadata.name"
-          image: releases-docker.jfrog.io/jfrog/artifactory-cpp-ce:{{ .Chart.Version }}
+          image: releases-docker.jfrog.io/jfrog/artifactory-{{ .Values.artifactory.product }}:{{ .Chart.Version }}
           name: {{ .Chart.Name }}
           ports:
             - containerPort: 8081

--- a/chart/templates/ingress.yaml
+++ b/chart/templates/ingress.yaml
@@ -4,11 +4,6 @@ metadata:
   name: {{ .Chart.Name }}-ingress
   annotations:
     nginx.ingress.kubernetes.io/proxy-body-size: "0"
-    nginx.ingress.kubernetes.io/rewrite-target: /$2
-{{- if and .Values.tls.enabled .Values.tls.host }}
-    nginx.ingress.kubernetes.io/configuration-snippet: |
-      more_set_input_headers "X-Artifactory-Override-Base-Url: https://{{ .Values.tls.host }}/{{ .Values.artifactory.path | default "artifactory" }}/artifactory";
-{{- end }}
 spec:
 {{- if .Values.tls.enabled }}
   tls:
@@ -22,7 +17,7 @@ spec:
   - http:
       paths:
         - pathType: Prefix
-          path: /{{ .Values.artifactory.path | default "artifactory" }}(/|$)(.*)
+          path: /
           backend:
             service:
               name: {{ .Chart.Name }}

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -10,4 +10,4 @@ tls:
   host: example-address.com
 
 artifactory:
-  path: artifactory
+  product: cpp-ce


### PR DESCRIPTION
It seems that Artifactory ignores "X-Artifactory-Override-Base-Url"
header. Though, the app will be accessible at any paths specified,
Artifactory UI is returned at /ui, anyway. Thus, install artifactory
app at the root path (/) so that both UI and Rest work correctly.

Signed-off-by: Nikita Vakula <programmistov.programmist@gmail.com>